### PR TITLE
Promote result types

### DIFF
--- a/src/Mutation.re
+++ b/src/Mutation.re
@@ -4,6 +4,13 @@ module type Config = {
   let parse: Js.Json.t => t;
 };
 
+type error = {. "message": string};
+
+type result('a) =
+  | Data('a)
+  | Error(error)
+  | NoData;
+
 module Make = (Config: Config) => {
   [@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag";
 
@@ -15,8 +22,6 @@ module Make = (Config: Config) => {
     client: ApolloClient.generatedApolloClient,
   };
 
-  type error = {. "message": string};
-
   [@bs.module "react-apollo-hooks"]
   external useMutation:
     (. ReasonApolloTypes.queryString, Js.Nullable.t(options)) =>
@@ -27,11 +32,6 @@ module Make = (Config: Config) => {
       "error": Js.Nullable.t(error),
     }) =
     "useMutation";
-
-  type result =
-    | Data(Config.t)
-    | Error(error)
-    | NoData;
 
   let use = (~options=?, ()) => {
     let jsMutate =

--- a/src/Query.re
+++ b/src/Query.re
@@ -4,10 +4,22 @@ module type Config = {
   let parse: Js.Json.t => t;
 };
 
+type error = {. "message": string};
+
+type variant('a) =
+  | Data('a)
+  | Error(error)
+  | Loading
+  | NoData;
+  
+type result('a) = {
+  data: option('a),
+  loading: bool,
+  error: option(error),
+};
+
 module Make = (Config: Config) => {
   [@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag";
-
-  type error = {. "message": string};
 
   [@bs.deriving abstract]
   type options = {
@@ -27,17 +39,6 @@ module Make = (Config: Config) => {
       "error": Js.Nullable.t(error),
     } =
     "useQuery";
-
-  type variant =
-    | Data(Config.t)
-    | Error(error)
-    | Loading
-    | NoData;
-  type result = {
-    data: option(Config.t),
-    loading: bool,
-    error: option(error),
-  };
 
   let use = (~options=?, ()) => {
     let jsResult =

--- a/src/Subscription.re
+++ b/src/Subscription.re
@@ -4,10 +4,22 @@ module type Config = {
   let parse: Js.Json.t => t;
 };
 
+type error = {. "message": string};
+
+type variant('a) =
+  | Data('a)
+  | Error(error)
+  | Loading
+  | NoData;
+
+type result('a) = {
+  data: option('a),
+  loading: bool,
+  error: option(error),
+};
+
 module Make = (Config: Config) => {
   [@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag";
-
-  type error = {. "message": string};
 
   [@bs.deriving abstract]
   type options = {
@@ -29,17 +41,6 @@ module Make = (Config: Config) => {
       "error": Js.Nullable.t(error),
     } =
     "useSubscription";
-
-  type variant =
-    | Data(Config.t)
-    | Error(error)
-    | Loading
-    | NoData;
-  type result = {
-    data: option(Config.t),
-    loading: bool,
-    error: option(error),
-  };
 
   let use = (~options=?, ()) => {
     let jsResult =


### PR DESCRIPTION
This promotes the result types to global types instead of having them inside of the module.

This allows for writing general code that takes the result of the hook, for instance:

```
[@react.component]
let make = (~query, ~children) => {
  switch (query) {
  | Error(err) =>
    <div className="my-4">
      <Alert type_=Error title="Error!" message=err />
    </div>
  | Loading
  | NoData => React.null
  | Data(data) => children(data)
  };
};
```