### PR TITLE
fix: jsResult##data parse when data is empty

### DIFF
--- a/src/Query.re
+++ b/src/Query.re
@@ -11,7 +11,7 @@ type variant('a) =
   | Error(error)
   | Loading
   | NoData;
-  
+
 type result('a) = {
   data: option('a),
   loading: bool,
@@ -46,7 +46,14 @@ module Make = (Config: Config) => {
 
     let result = {
       data:
-        jsResult##data->Js.Nullable.toOption->Belt.Option.map(Config.parse),
+        jsResult##data
+        ->Js.Nullable.toOption
+        ->Belt.Option.flatMap(data =>
+            switch (Config.parse(data)) {
+            | parsedData => Some(parsedData)
+            | exception _ => None
+            }
+          ),
       loading: jsResult##loading,
       error: jsResult##error->Js.Nullable.toOption,
     };


### PR DESCRIPTION
Fixes an issue reported in https://github.com/mhallin/graphql_ppx/issues/84. Apollo client can return us empty object which is passed to Config.parse which throws an exception. It's solved the same way as in reason-apollo: https://github.com/apollographql/reason-apollo/blob/master/src/graphql-types/ReasonApolloQuery.re#L103