### PR TITLE
useMemo for mutation result

### DIFF
--- a/src/Mutation.re
+++ b/src/Mutation.re
@@ -86,22 +86,33 @@ module Make = (Config: Config) => {
         [|variables|],
       );
 
-    let full = {
-      loading: jsResult##loading,
-      called: jsResult##called,
-      data:
-        jsResult##data->Js.Nullable.toOption->Belt.Option.map(Config.parse),
-      error: jsResult##error->Js.Nullable.toOption,
-    };
+     let full =
+      React.useMemo1(
+        () =>
+          {
+            loading: jsResult##loading,
+            called: jsResult##called,
+            data:
+              jsResult##data
+              ->Js.Nullable.toOption
+              ->Belt.Option.map(Config.parse),
+            error: jsResult##error->Js.Nullable.toOption,
+          },
+        [|jsResult|],
+      );
 
     let simple =
-      switch (full) {
-      | {loading: true} => Loading
-      | {error: Some(error)} => Error(error)
-      | {data: Some(data)} => Data(data)
-      | {called: true} => Called
-      | _ => NoData
-      };
+      React.useMemo1(
+        () =>
+          switch (full) {
+          | {loading: true} => Loading
+          | {error: Some(error)} => Error(error)
+          | {data: Some(data)} => Data(data)
+          | {called: true} => Called
+          | _ => NoData
+          },
+        [|full|],
+      );
 
     (mutate, simple, full);
   };


### PR DESCRIPTION
I had a use case where I wanted to run some effect only if the mutation result was different. 
But just putting the mutation result as a dependency of the `useEffect` didn't work; If the mutation was fired again, even if the result was identical to the first one, the effect ran again because the result was a new value.
With this fix, the result is only created again if it was also created again from the `js` side.