### PR TITLE
Update binding to graphql-tag to work w/ es6.

### DIFF
--- a/src/Query.re
+++ b/src/Query.re
@@ -49,7 +49,7 @@ type fetchMoreOptions = {
 };
 
 module Make = (Config: Config) => {
-  [@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag";
+  [@bs.module "graphql-tag"] external gql: ReasonApolloTypes.gql = "default";
 
   [@bs.deriving abstract]
   type options = {


### PR DESCRIPTION
The binding wasn't generating the correct code when using es6 instead of commonjs. This works with both.