### PR TITLE
Add fetch policy and cache update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Then update your bsconfig.json
 ```
 
 ## Setting up
+
 Add the provider in the top of the tree
 
 ```reason
@@ -57,7 +58,6 @@ ReactDOMRe.renderToElementWithId(
 );
 ```
 
-
 # Available hooks
 
 ## useQuery
@@ -91,6 +91,7 @@ let make = () => {
   </div>
 }
 ```
+
 Using the `full` record for more advanced cases
 
 ```reason
@@ -113,6 +114,11 @@ let make = () => {
 }
 ```
 
+Using `fetchPolicy` to change interactions with the `apollo` cache, see [apollo docs](https://www.apollographql.com/docs/react/api/react-apollo/#optionsfetchpolicy).
+
+```reason
+let (_simple, full) = UserQuery.use(~fetchPolicy=NetworkOnly, ());
+```
 
 ## useMutation
 

--- a/README.md
+++ b/README.md
@@ -163,13 +163,13 @@ let make = () => {
 
 ## Cache
 
-There are a couple of issues with manual cache updates.
+There are a couple of caveats with manual cache updates.
 
-`reason-apollo-hooks` will parse response data from a query or mutation using parse function created by `graphql_ppx`. For example, when using `@bsRecord` directive, the response object will be parsed from a `Js.t` object to a reason record. In this case, the response data in reason code is not the same object that is stored in cache, since `react-apollo` saves data in cache before it is parsed by `reason-apollo-hooks` and returned to the component. However, when updating cache, the data must be in the same format or apollo cache won't work correctly and throw errors.
+`reason-apollo-hooks` parses response data from a query or mutation using parse function created by `graphql_ppx`. For example, when using `@bsRecord` directive, the response object will be parsed from a `Js.t` object to a reason record. In this case, the response data in reason code is not the same object that is stored in cache, since `react-apollo` saves data in cache before it is parsed and returned to the component. However, when updating cache, the data must be in the same format or apollo cache won't work correctly and throw errors.
 
-If using directives like `@bsRecord`, `@bsDecoder` or `@bsVariant` in `graphql_ppx`, the data needs to be serialized back to JS object before it is written in cache. Since there is currently no way to serialize this data (see [this open issue](https://github.com/mhallin/graphql_ppx/issues/71) in `graphql_ppx`), queries that will be updated manually in cache shouldn't use any of those directive, unless you will take care of the serialization yourself.
+If using directives like `@bsRecord`, `@bsDecoder` or `@bsVariant` in `graphql_ppx`, the data needs to be serialized back to JS object before it is written in cache. Since there is currently no way to serialize this data (see [this issue](https://github.com/mhallin/graphql_ppx/issues/71) in `graphql_ppx`), queries that will be updated in cache shouldn't use any of those directive, unless you will take care of the serialization yourself.
 
-Another issue is that by default, apollo will add field `__typename` to the queries and will use it to normalize data and manipulate cache (see [normalization](https://www.apollographql.com/docs/react/advanced/caching/#normalization)). This field won't exist on parsed reason objects, since it is not included in the actual query you write, but is added by apollo before sending the query. Since `__typename` is crucial for the cache to work correctly, we need to read data from cache in its raw unparsed format, which is achieved with `readQuery` from `ApolloClient.ReadQuery` defined in `reason-apollo`.
+By default, apollo will add field `__typename` to the queries and will use it to normalize data and manipulate cache (see [normalization](https://www.apollographql.com/docs/react/advanced/caching/#normalization)). This field won't exist on parsed reason objects, since it is not included in the actual query you write, but is added by apollo before sending the query. Since `__typename` is crucial for the cache to work correctly, we need to read data from cache in its raw unparsed format, which is achieved with `readQuery` from `ApolloClient.ReadQuery` defined in `reason-apollo`.
 
 An example of cache update could look like this:
 

--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ let make = () => {
 
 There are a couple of caveats with manual cache updates.
 
-`reason-apollo-hooks` parses response data from a query or mutation using parse function created by `graphql_ppx`. For example, when using `@bsRecord` directive, the response object will be parsed from a `Js.t` object to a reason record. In this case, the response data in reason code is not the same object that is stored in cache, since `react-apollo` saves data in cache before it is parsed and returned to the component. However, when updating cache, the data must be in the same format or apollo cache won't work correctly and throw errors.
+**TL;DR**
 
-If using directives like `@bsRecord`, `@bsDecoder` or `@bsVariant` in `graphql_ppx`, the data needs to be serialized back to JS object before it is written in cache. Since there is currently no way to serialize this data (see [this issue](https://github.com/mhallin/graphql_ppx/issues/71) in `graphql_ppx`), queries that will be updated in cache shouldn't use any of those directive, unless you will take care of the serialization yourself.
-
-By default, apollo will add field `__typename` to the queries and will use it to normalize data and manipulate cache (see [normalization](https://www.apollographql.com/docs/react/advanced/caching/#normalization)). This field won't exist on parsed reason objects, since it is not included in the actual query you write, but is added by apollo before sending the query. Since `__typename` is crucial for the cache to work correctly, we need to read data from cache in its raw unparsed format, which is achieved with `readQuery` from `ApolloClient.ReadQuery` defined in `reason-apollo`.
+1. If you need to remove items from cached data, it is enough to just filter them out and save the result into cache as is.
+2. If you need to add the result of a mutation to a list of items with the same shape, you simply concat it with the list and save into cache as it.
+3. When you need to update a field, you have to resort to raw javascript to use spread operator on `Js.t` object in order to preserve `__typename` that `apollo` adds to all queries by default.
 
 An example of cache update could look like this:
 
@@ -233,6 +233,12 @@ let updatePersons = (~client, ~name, ~age) => {
   };
 };
 ```
+
+`reason-apollo-hooks` parses response data from a query or mutation using parse function created by `graphql_ppx`. For example, when using `@bsRecord` directive, the response object will be parsed from a `Js.t` object to a reason record. In this case, the response data in reason code is not the same object that is stored in cache, since `react-apollo` saves data in cache before it is parsed and returned to the component. However, when updating cache, the data must be in the same format or apollo cache won't work correctly and throw errors.
+
+If using directives like `@bsRecord`, `@bsDecoder` or `@bsVariant` in `graphql_ppx`, the data needs to be serialized back to JS object before it is written in cache. Since there is currently no way to serialize this data (see [this issue](https://github.com/mhallin/graphql_ppx/issues/71) in `graphql_ppx`), queries that will be updated in cache shouldn't use any of those directive, unless you will take care of the serialization yourself.
+
+By default, apollo will add field `__typename` to the queries and will use it to normalize data and manipulate cache (see [normalization](https://www.apollographql.com/docs/react/advanced/caching/#normalization)). This field won't exist on parsed reason objects, since it is not included in the actual query you write, but is added by apollo before sending the query. Since `__typename` is crucial for the cache to work correctly, we need to read data from cache in its raw unparsed format, which is achieved with `readQuery` from `ApolloClient.ReadQuery` defined in `reason-apollo`.
 
 ## Getting it running
 

--- a/examples/persons/src/FilterByNameCache.re
+++ b/examples/persons/src/FilterByNameCache.re
@@ -1,3 +1,13 @@
+/**
+ * Query response will be parsed using Config.parse from graphq_ppx before it is accessed in
+ * reason, but react-apollo will save it in cache in its original format, as a regular JS object,
+ * and apollo requires the data to be saved in cache in the same format or cache won't work correctly.
+ *
+ * If using directives like @bsRecord, @bsDecoder or @bsVariant on the query result, the data
+ * in cache and the parsed data won't to have the same format. Since there is currently no way
+ * to serialize the parsed data back to its initial format, queries that will be updated manually
+ * in cache can't use any of those directive, unless you will take care of the serialization yourself.
+ */
 module PersonsNameFilterConfig = [%graphql
   {|
   query getPersonsWithName($name: String!) {
@@ -40,25 +50,28 @@ let updateCache = (client, person, name) => {
   let readQueryOptions =
     ReasonApolloHooks.Utils.toReadQueryOptions(filterByNameQuery);
 
+  // By default, apollo cache adds field __typename to the query and will use it
+  // to normalize data. Parsing the result with Config.parse will remove the field,
+  // which won't allow to save the data back to cache. This means we can't use ReadQuery.make,
+  // which parses cache result, and have to use the readQuery which returns Json.t.
   switch (PersonsNameFilterReadQuery.readQuery(client, readQueryOptions)) {
   | exception _ => ()
   | cachedResponse =>
     switch (cachedResponse |> Js.Nullable.toOption) {
     | None => ()
     | Some(cachedPersons) =>
+      // readQuery returns unparsed data as Json.t, but since PersonsNameFilterQuery
+      // is not using any graphql_ppx directive, the data will have the same format,
+      // (with the addition of __typename field) and can be cast to PersonsNameFilterConfig.t.
       let persons = cast(cachedPersons);
       let updatedPersons = {
         "allPersons": updateFiltered(person, name, persons##allPersons),
       };
 
-      let mergeCacheJs: ('a, 'a) => 'a = [%bs.raw
-        {| function (prev, next) {  return { ...prev, ...next }; } |}
-      ];
-
       PersonsNameFilterWriteQuery.make(
         ~client,
         ~variables=filterByNameQuery##variables,
-        ~data=mergeCacheJs(persons, updatedPersons),
+        ~data=updatedPersons,
         (),
       );
     }

--- a/examples/persons/src/FilterByNameCache.re
+++ b/examples/persons/src/FilterByNameCache.re
@@ -50,7 +50,7 @@ let updateCache = (client, person, name) => {
   let readQueryOptions =
     ReasonApolloHooks.Utils.toReadQueryOptions(filterByNameQuery);
 
-  // By default, apollo cache adds field __typename to the query and will use it
+  // By default, apollo adds field __typename to the query and will use it
   // to normalize data. Parsing the result with Config.parse will remove the field,
   // which won't allow to save the data back to cache. This means we can't use ReadQuery.make,
   // which parses cache result, and have to use the readQuery which returns Json.t.

--- a/src/Query.re
+++ b/src/Query.re
@@ -59,6 +59,8 @@ module Make = (Config: Config) => {
     client: ApolloClient.generatedApolloClient,
     [@bs.optional]
     notifyOnNetworkStatusChange: bool,
+    [@bs.optional]
+    fetchPolicy: string,
   };
 
   [@bs.module "@apollo/react-hooks"]
@@ -76,11 +78,24 @@ module Make = (Config: Config) => {
     } =
     "useQuery";
 
-  let use = (~variables=?, ~client=?, ~notifyOnNetworkStatusChange=?, ()) => {
+  let use =
+      (
+        ~variables=?,
+        ~client=?,
+        ~notifyOnNetworkStatusChange=?,
+        ~fetchPolicy=?,
+        (),
+      ) => {
     let jsResult =
       useQuery(
         gql(. Config.query),
-        options(~variables?, ~client?, ~notifyOnNetworkStatusChange?, ()),
+        options(
+          ~variables?,
+          ~client?,
+          ~notifyOnNetworkStatusChange?,
+          ~fetchPolicy=?fetchPolicy->Belt.Option.map(Types.fetchPolicyToJs),
+          (),
+        ),
       );
 
     let result =

--- a/src/Types.re
+++ b/src/Types.re
@@ -23,3 +23,23 @@ let toNetworkStatus = (status: Js.Nullable.t(int)) => {
   | _ => Unknown
   };
 };
+
+/**
+ * apollo-client/src/core/watchQueryOptions.ts
+ */
+type fetchPolicy =
+  | CacheFirst
+  | NetworkOnly
+  | CacheOnly
+  | NoCache
+  | Standby;
+
+let fetchPolicyToJs = fetchPolicy => {
+  switch (fetchPolicy) {
+  | CacheFirst => "cache-first"
+  | NetworkOnly => "network-only"
+  | CacheOnly => "cache-only"
+  | NoCache => "no-cache"
+  | Standby => "standby"
+  };
+};


### PR DESCRIPTION
This PR adds `fetchPolicy` for `useQuery`, [here](https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/watchQueryOptions.ts#L18) is the source code for `fetchPolicy` option in `apollo-client`. I have also cleaned up the example with cache and removed some unnecessary raw JS and wrote some comments. I got a bit too carried away and wrote a bit of a too extensive explanation in the README, I can remove it if it is too much 😀 

I felt like there are just too many caveats with updating `apollo` cache and other people are stumbling onto it too.  The reasons are, first of all, that graphql response is parsed and there is no serialisation mechanism to transform the data back to the JS format (that have to be in cache), and second, the good ol' `__typename` that needs to be in cache but is not accessible in the reason code 🙃