### PR TITLE
Mutation type

### DIFF
--- a/src/Mutation.re
+++ b/src/Mutation.re
@@ -64,7 +64,7 @@ module Make = (Config: Config) => {
   };
 
   type jsMutate = (. options) => Js.Promise.t(jsResult);
-  type mutate =
+  type mutation =
     (
       ~variables: Js.Json.t=?,
       ~client: ApolloClient.generatedApolloClient=?,
@@ -101,7 +101,7 @@ module Make = (Config: Config) => {
         ),
       );
 
-    let mutate: mutate =
+    let mutate: mutation =
       React.useMemo1(
         (
           (),

--- a/src/Mutation.re
+++ b/src/Mutation.re
@@ -12,6 +12,9 @@ type error = {
   "graphlErrors": graphqlErrors,
 };
 
+type refetchQueries =
+  ReasonApolloTypes.executionResult => array(ApolloClient.queryObj);
+
 /* Result that is return by the hook */
 type result('a) =
   | Data('a)
@@ -45,8 +48,7 @@ module Make = (Config: Config) => {
     [@bs.optional]
     client: ApolloClient.generatedApolloClient,
     [@bs.optional]
-    refetchQueries:
-      ReasonApolloTypes.executionResult => array(ApolloClient.queryObj),
+    refetchQueries,
     [@bs.optional]
     awaitRefetchQueries: bool,
     [@bs.optional]
@@ -62,6 +64,15 @@ module Make = (Config: Config) => {
   };
 
   type jsMutate = (. options) => Js.Promise.t(jsResult);
+  type mutate =
+    (
+      ~variables: Js.Json.t=?,
+      ~client: ApolloClient.generatedApolloClient=?,
+      ~refetchQueries: refetchQueries=?,
+      ~awaitRefetchQueries: bool=?,
+      unit
+    ) =>
+    Js.Promise.t(controledVariantResult(Config.t));
 
   [@bs.module "@apollo/react-hooks"]
   external useMutation:
@@ -90,7 +101,7 @@ module Make = (Config: Config) => {
         ),
       );
 
-    let mutate =
+    let mutate: mutate =
       React.useMemo1(
         (
           (),


### PR DESCRIPTION
This PR adds a type for the `mutate` function, similar to [`apolloMutation`](https://github.com/apollographql/reason-apollo/blob/master/src/graphql-types/ReasonApolloMutation.re#L63), according to issue #37 .

I annotated the `mutate` function directly to make sure the type doesn't become stale when the actual function changes, is it the right approach, @fakenickels ?