### PR TITLE
Add errorPolicy to useQuery.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ Using `fetchPolicy` to change interactions with the `apollo` cache, see [apollo 
 let (_simple, full) = UserQuery.use(~fetchPolicy=NetworkOnly, ());
 ```
 
+Using `errorPolicy` to change how errors are handled, see [apollo docs](https://www.apollographql.com/docs/react/api/react-apollo/#optionserrorpolicy).
+
+```reason
+let (simple, _full) = UserQuery.use(~errorPolicy=All, ());
+```
+
 ## useMutation
 
 ```reason

--- a/src/Types.re
+++ b/src/Types.re
@@ -11,7 +11,7 @@ type networkStatus =
   | Error
   | Unknown;
 
-let toNetworkStatus = (status: Js.Nullable.t(int)) => {
+let toNetworkStatus = (status: Js.Nullable.t(int)) =>
   switch (status->Js.Nullable.toOption) {
   | Some(1) => Loading
   | Some(2) => SetVariables
@@ -22,7 +22,6 @@ let toNetworkStatus = (status: Js.Nullable.t(int)) => {
   | Some(8) => Error
   | _ => Unknown
   };
-};
 
 /**
  * apollo-client/src/core/watchQueryOptions.ts
@@ -34,7 +33,7 @@ type fetchPolicy =
   | NoCache
   | Standby;
 
-let fetchPolicyToJs = fetchPolicy => {
+let fetchPolicyToJs = fetchPolicy =>
   switch (fetchPolicy) {
   | CacheFirst => "cache-first"
   | NetworkOnly => "network-only"
@@ -42,4 +41,18 @@ let fetchPolicyToJs = fetchPolicy => {
   | NoCache => "no-cache"
   | Standby => "standby"
   };
-};
+
+/**
+ * apollo-client/src/core/watchQueryOptions.ts
+ */
+type errorPolicy =
+  | None
+  | Ignore
+  | All;
+
+let errorPolicyToJs = errorPolicy =>
+  switch (errorPolicy) {
+  | None => "none"
+  | Ignore => "ignore"
+  | All => "all"
+  };


### PR DESCRIPTION
This just adds the `errorPolicy` param to the `useQuery` params.

https://www.apollographql.com/docs/react/api/react-apollo/#optionserrorpolicy