### PR TITLE
fix: make compatible with bs-platform 7, update example

### DIFF
--- a/examples/persons/bsconfig.json
+++ b/examples/persons/bsconfig.json
@@ -15,7 +15,7 @@
   ],
   "suffix": ".bs.js",
   "namespace": true,
-  "ppx-flags": ["@baransu/graphql_ppx_re/ppx"],
+  "ppx-flags": ["@baransu/graphql_ppx_re/ppx6"],
   "bs-dependencies": ["reason-react", "reason-apollo", "reason-apollo-hooks"],
   "refmt": 3
 }

--- a/examples/persons/package.json
+++ b/examples/persons/package.json
@@ -22,14 +22,14 @@
     "@apollo/react-hooks": "^3.1.1",
     "react": "^16.10.1",
     "react-dom": "^16.10.1",
-    "reason-apollo": "^0.17.0",
+    "reason-apollo": "^0.18.0",
     "reason-apollo-hooks": "../../",
     "reason-react": ">=0.7.0"
   },
   "devDependencies": {
-    "bs-platform": "^5.2.0",
+    "bs-platform": "^7.0.1",
     "css-loader": "^3.2.0",
-    "@baransu/graphql_ppx_re": "^0.4.0",
+    "@baransu/graphql_ppx_re": "^0.4.6",
     "html-webpack-plugin": "^3.2.0",
     "style-loader": "^1.0.0",
     "webpack": "^4.0.1",

--- a/examples/persons/src/Persons.re
+++ b/examples/persons/src/Persons.re
@@ -14,8 +14,6 @@ let personsPerPage = 10;
 
 [@react.component]
 let make = () => {
-  let skipRef = React.useRef(0);
-
   let (_simple, full) =
     ApolloHooks.useQuery(
       ~variables=
@@ -25,8 +23,11 @@ let make = () => {
     );
 
   let handleLoadMore = _ => {
-    let skip = React.Ref.current(skipRef) + personsPerPage;
-    skipRef->React.Ref.setCurrent(skip);
+    let skip =
+      switch (full) {
+      | {data: Some(data)} => data##allPersons->Belt.Array.length
+      | _ => 0
+      };
 
     full.fetchMore(
       ~variables=

--- a/examples/persons/yarn.lock
+++ b/examples/persons/yarn.lock
@@ -20,10 +20,10 @@
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 
-"@baransu/graphql_ppx_re@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@baransu/graphql_ppx_re/-/graphql_ppx_re-0.4.0.tgz#24f01e19d030768bba85a8676c70679c8fb63725"
-  integrity sha512-vCWaBTbLRHDRvl72e80UH1Xo6Rp7JaBJgBgt24jBX1zXPdpvELObwxapmaSdPHK+wI31X0fRJu9z6yD7IAlBDA==
+"@baransu/graphql_ppx_re@^0.4.6":
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/@baransu/graphql_ppx_re/-/graphql_ppx_re-0.4.6.tgz#cd4e20a5c5496a665e08aca0f4dea78ecca2e0d7"
+  integrity sha512-BlVNBF4926NPdhODAdemGeCFsPw7HNWLo3o2kQM2kr+6XXrog86etwRN/2/4Xa8KUzqKWM2ohjJEbbZE/cIHyQ==
 
 "@types/events@*":
   version "3.0.0"
@@ -684,10 +684,10 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-bs-platform@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.2.0.tgz#0ec317273daed573491c105f68ea48826a285b7a"
-  integrity sha512-miyePsOF9VbuhT5QD5E/hb+l454Fo4MAcg5xV1GJhbWxmejuF/X7mCYUsNrK1UUAaYt8hnoyFdeLG22sxVta9A==
+bs-platform@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.0.1.tgz#1d7b0ef6088b998dceee5db74a7cd8f01c20a3bd"
+  integrity sha512-UjStdtHhbtC/l6vKJ1XRDqrPk7rFf5PLYHtRX3akDXEYVnTbN36z0g4DEr5mU8S0N945e33HYts9x+i7hKKpZQ==
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -3571,12 +3571,12 @@ readdirp@^2.2.1:
     readable-stream "^2.0.2"
 
 reason-apollo-hooks@../../:
-  version "2.6.0"
+  version "3.0.0"
 
-reason-apollo@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/reason-apollo/-/reason-apollo-0.17.0.tgz#44e5930028a26378dcc44fd3545dd36c84ab665b"
-  integrity sha512-3o0eit+uxkbRkkdzYnK+tV5oSWwmNWczT9qdSJKNCpu0R/NYE5qfpSBX7ouJUnE1j4arxgXDs2Ryey47QNYwrw==
+reason-apollo@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/reason-apollo/-/reason-apollo-0.18.0.tgz#cc970da88de7ac603753eed68984c8492f0665c6"
+  integrity sha512-lw+IoIZ8qoX3iGOFFK//yMVC+Xmf+OcSyKkRgbBn0uG5GomLLMLiKRgjkhUsjAqJ4b3Se7H9JFnso5nL+GFEMA==
   dependencies:
     apollo-cache-inmemory "^1.6.0"
     apollo-client "^2.6.3"

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "bs-platform": "^5.0.6",
     "husky": "^3.0.5",
     "lint-staged": "^9.4.0",
-    "reason-apollo": "^0.17.0",
+    "reason-apollo": "^0.18.0",
     "reason-react": ">=0.7.0"
   },
   "peerDependencies": {
     "@apollo/react-hooks": "^3.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "reason-apollo": "^0.17.0",
+    "reason-apollo": "^0.18.0",
     "reason-react": ">=0.7.0"
   },
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1803,10 +1803,10 @@ readable-stream@~2.3.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-reason-apollo@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/reason-apollo/-/reason-apollo-0.17.0.tgz#44e5930028a26378dcc44fd3545dd36c84ab665b"
-  integrity sha512-3o0eit+uxkbRkkdzYnK+tV5oSWwmNWczT9qdSJKNCpu0R/NYE5qfpSBX7ouJUnE1j4arxgXDs2Ryey47QNYwrw==
+reason-apollo@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/reason-apollo/-/reason-apollo-0.18.0.tgz#cc970da88de7ac603753eed68984c8492f0665c6"
+  integrity sha512-lw+IoIZ8qoX3iGOFFK//yMVC+Xmf+OcSyKkRgbBn0uG5GomLLMLiKRgjkhUsjAqJ4b3Se7H9JFnso5nL+GFEMA==
   dependencies:
     apollo-cache-inmemory "^1.6.0"
     apollo-client "^2.6.3"


### PR DESCRIPTION
This PR updates `reason-apollo` to latest version, which works for `bs-platform` > 5, and updates the example to latest `bs-platform`.