### PR TITLE
Uses error types from ReasonApollo

### DIFF
--- a/src/ApolloHooksMutation.re
+++ b/src/ApolloHooksMutation.re
@@ -1,10 +1,4 @@
-type graphqlErrors;
-
-type error = {
-  .
-  "message": string,
-  "graphqlErrors": graphqlErrors,
-};
+open ApolloHooksTypes;
 
 type refetchQueries =
   ReasonApolloTypes.executionResult => array(ApolloClient.queryObj);
@@ -12,7 +6,7 @@ type refetchQueries =
 /* Result that is return by the hook */
 type result('a) =
   | Data('a)
-  | Error(error)
+  | Error(apolloError)
   | NoData;
 
 /* Result that is return by the hook */
@@ -20,14 +14,14 @@ type controlledResult('a) = {
   loading: bool,
   called: bool,
   data: option('a),
-  error: option(error),
+  error: option(apolloError),
 };
 
 type controlledVariantResult('a) =
   | Loading
   | NotCalled
   | Data('a)
-  | Error(error)
+  | Error(apolloError)
   | NoData;
 
 [@bs.module "graphql-tag"] external gql: ReasonApolloTypes.gql = "default";
@@ -57,7 +51,7 @@ type jsResult = {
   "data": Js.Nullable.t(Js.Json.t),
   "loading": bool,
   "called": bool,
-  "error": Js.Nullable.t(error),
+  "error": Js.Nullable.t(apolloError),
 };
 
 type jsMutate('a) = (. options('a)) => Js.Promise.t(jsResult);
@@ -158,12 +152,14 @@ let useMutation:
 
     let full =
       React.useMemo1(
-        () => {
-          loading: jsResult##loading,
-          called: jsResult##called,
-          data: jsResult##data->Js.Nullable.toOption->Belt.Option.map(parse),
-          error: jsResult##error->Js.Nullable.toOption,
-        },
+        () =>
+          {
+            loading: jsResult##loading,
+            called: jsResult##called,
+            data:
+              jsResult##data->Js.Nullable.toOption->Belt.Option.map(parse),
+            error: jsResult##error->Js.Nullable.toOption,
+          },
         [|jsResult|],
       );
 

--- a/src/ApolloHooksQuery.re
+++ b/src/ApolloHooksQuery.re
@@ -1,9 +1,8 @@
 open ApolloHooksTypes;
-type queryError = {. "message": string};
 
 type variant('a) =
   | Data('a)
-  | Error(queryError)
+  | Error(apolloError)
   | Loading
   | NoData;
 
@@ -25,7 +24,7 @@ type refetch('a) = (~variables: Js.Json.t=?, unit) => Js.Promise.t('a);
 type queryResult('a) = {
   data: option('a),
   loading: bool,
-  error: option(queryError),
+  error: option(apolloError),
   refetch: refetch('a),
   fetchMore:
     (~variables: Js.Json.t=?, ~updateQuery: updateQueryT, unit) =>
@@ -70,7 +69,7 @@ external useQueryJs:
     .
     "data": Js.Nullable.t(Js.Json.t),
     "loading": bool,
-    "error": Js.Nullable.t(queryError),
+    "error": Js.Nullable.t(apolloError),
     [@bs.meth]
     "refetch": Js.Nullable.t(Js.Json.t) => Js.Promise.t(Js.Json.t),
     [@bs.meth] "fetchMore": fetchMoreOptions => Js.Promise.t(unit),

--- a/src/ApolloHooksTypes.re
+++ b/src/ApolloHooksTypes.re
@@ -61,6 +61,28 @@ let errorPolicyToJs = errorPolicy =>
   | All => "all"
   };
 
+/**
+ * apollo-client/src/errors/ApolloError.ts
+ */
+type apolloErrorExtensions = {. "code": Js.Nullable.t(string)};
+
+type graphqlError = {
+  .
+  "message": string,
+  "name": Js.Nullable.t(string),
+  "extensions": Js.Nullable.t(apolloErrorExtensions),
+  "locations": Js.Nullable.t(array(string)),
+  "path": Js.Nullable.t(array(string)),
+  "nodes": Js.Nullable.t(array(string)),
+};
+
+type apolloError = {
+  .
+  "message": string,
+  "graphQLErrors": Js.Nullable.t(array(graphqlError)),
+  "networkError": Js.Nullable.t(string),
+};
+
 type parse('a) = Js.Json.t => 'a;
 type query = string;
 type composeVariables('returnType, 'hookReturnType) =


### PR DESCRIPTION
This PR simply copies the error types from `reason-apollo` into `ApolloHooksTypes.re`. I could have just used `ReasonApolloTypes.apolloError`, but thought it best to not create another dependency between `reason-apollo-hooks` and `reason-apollo`.

I decided against converting the deeper js types to reason, but let me know if that's preferred and I'll update this.