### PR TITLE
fix: makes mutate promise return Error even if there was data

### DIFF
--- a/src/ApolloHooksMutation.re
+++ b/src/ApolloHooksMutation.re
@@ -142,8 +142,8 @@ let useMutation:
                    Js.Nullable.toOption(jsResult##data),
                    Js.Nullable.toOption(jsResult##error),
                  ) {
-                 | (Some(data), _) => (Data(parse(data)): result('data))
-                 | (None, Some(error)) => Error(error)
+                 | (_, Some(error)) => (Error(error): result('data))
+                 | (Some(data), _) => Data(parse(data))
                  | (None, None) => NoData
                  }
                )


### PR DESCRIPTION
This PR reorders the switch that produced the `result('data)` returned by the `mutate` function, so that the promise resolves to `Error` when when error is non-null and data is either, whereas the previous version only resolves to `Error` when data is null.

This make the behaviour consistent with the `controlledVariantResult('data)`.