### PR TITLE
Adds basic query context support

### DIFF
--- a/src/ApolloHooksQuery.re
+++ b/src/ApolloHooksQuery.re
@@ -93,6 +93,8 @@ type options = {
   skip: bool,
   [@bs.optional]
   pollInterval: int,
+  [@bs.optional]
+  context: Context.t,
 };
 
 [@bs.module "@apollo/react-hooks"]
@@ -122,6 +124,7 @@ let useQuery:
     ~errorPolicy: ApolloHooksTypes.errorPolicy=?,
     ~skip: bool=?,
     ~pollInterval: int=?,
+    ~context: Context.t=?,
     graphqlDefinition('data, _, _)
   ) =>
   (variant('data), queryResult('data)) =
@@ -133,6 +136,7 @@ let useQuery:
     ~errorPolicy=?,
     ~skip=?,
     ~pollInterval=?,
+    ~context=?,
     (parse, query, _),
   ) => {
     let jsResult =
@@ -148,6 +152,7 @@ let useQuery:
             errorPolicy->Belt.Option.map(ApolloHooksTypes.errorPolicyToJs),
           ~skip?,
           ~pollInterval?,
+          ~context?,
           (),
         ),
       );

--- a/src/ApolloHooksTypes.re
+++ b/src/ApolloHooksTypes.re
@@ -95,6 +95,7 @@ type graphqlDefinition('data, 'returnType, 'hookReturnType) = (
 );
 
 module Context = {
-  type t;
-  let make = context => Js.Dict.fromList(context);
+  type t('a) = Js.Dict.t('a);
+  let make = (context: list((string, 'a))): t('a) =>
+    Js.Dict.fromList(context);
 };

--- a/src/ApolloHooksTypes.re
+++ b/src/ApolloHooksTypes.re
@@ -95,7 +95,6 @@ type graphqlDefinition('data, 'returnType, 'hookReturnType) = (
 );
 
 module Context = {
-  type t('a) = Js.Dict.t('a);
-  let make = (context: list((string, 'a))): t('a) =>
-    Js.Dict.fromList(context);
+  type t = Js.Dict.t(string);
+  let make = (context): t => Js.Dict.fromList(context);
 };

--- a/src/ApolloHooksTypes.re
+++ b/src/ApolloHooksTypes.re
@@ -93,3 +93,8 @@ type graphqlDefinition('data, 'returnType, 'hookReturnType) = (
   query,
   composeVariables('returnType, 'hookReturnType),
 );
+
+module Context = {
+  type t;
+  let make = context => Js.Dict.fromList(context);
+};


### PR DESCRIPTION
This is a WIP until I can test it a bit, but the idea is to give consumers basic access to the query context through a key-value map.

~The usual case will be (key: string, value: string), but I didn't really see a need to contrain the type of value so I have not yet done so.~

This approach led to a little too much type annotation, so I'm sticking with <string, string> for now, even though Apollo supports <string, any>